### PR TITLE
Update elementsd (liquidd) to 0.18.1.9 (#263)

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -19,11 +19,11 @@ RUN curl -sL -o bitcoin.tar.gz https://bitcoincore.org/bin/bitcoin-core-0.20.0/b
  && ln -s /srv/explorer/bitcoin-0.20.0 /srv/explorer/bitcoin \
  && rm bitcoin.tar.gz
 
-ENV SHA256SUM_ELEMENTS=efab2e8799053f8341b0fb6d3eee055d925177ed8c0201a87e47ffb40ce50d46
-RUN curl -sL -o elements.tar.gz https://github.com/ElementsProject/elements/releases/download/elements-0.18.1.8/elements-0.18.1.8-x86_64-linux-gnu.tar.gz \
+ENV SHA256SUM_ELEMENTS=52f1993efdc52b1b9779040812bc622580c1240282e6cfc95a0d3333deaa2a2c
+RUN curl -sL -o elements.tar.gz https://github.com/ElementsProject/elements/releases/download/elements-0.18.1.9/elements-0.18.1.9-x86_64-linux-gnu.tar.gz \
  && echo "${SHA256SUM_ELEMENTS}  elements.tar.gz" | sha256sum --check \
  && tar xzf elements.tar.gz -C /srv/explorer \
- && ln -s /srv/explorer/elements-0.18.1.8 /srv/explorer/liquid \
+ && ln -s /srv/explorer/elements-0.18.1.9 /srv/explorer/liquid \
  && mv /srv/explorer/liquid/bin/{elementsd,liquidd} \
  && mv /srv/explorer/liquid/bin/{elements-cli,liquid-cli} \
  && rm elements.tar.gz


### PR DESCRIPTION
Co-authored-by: Phil McLean <phil@blockstream.com>